### PR TITLE
Update battle_calculator.php5

### DIFF
--- a/revolution/battle_calculator.php5
+++ b/revolution/battle_calculator.php5
@@ -86,7 +86,7 @@ class BattleCalculator {
 			// Time to compute Damage
 			$total_attackers->damage = $this->get_damage($total_defenders, $total_attackers);
 			$total_defenders->damage = $this->get_damage($total_attackers, $total_defenders);
-			$total_attackers->captured = $this->get_creature_capture($total_defenders*2.0, $total_attackers);
+			$total_attackers->captured = $this->get_creature_capture($total_defenders, $total_attackers);
 			$total_defenders->captured = $this->get_creature_capture($total_attackers, $total_defenders);
 			$total_attackers->structures_captured = $this->get_structure_capture($total_attackers, $total_defenders);
 			$cap_structures = floor (($pd->unassigned + $pd->extractor + $pd->genetic_lab + $pd->powerplant + $pd->factory) * 0.10);


### PR DESCRIPTION
I don't think this is allowed: $total_defenders*2.0
It is somehow causing the attacker creatures captured to be 0. I am assuming its this because there is nothing else I could find that would be the problem but I am not sure.
