### PR TITLE
Update battle_calculator.php5

### DIFF
--- a/revolution/battle_calculator.php5
+++ b/revolution/battle_calculator.php5
@@ -168,6 +168,8 @@ class BattleCalculator {
 						if ($dm->does_player_know_development($player, "Battlefield Immunity")) {
 // Commented out to allow BFI creatures to be captured
 //							$fd->creatures_lost["$creature"] = 0; 
+							if ($defender_has_capture_mastery) {
+								$fd->creatures_lost["Screature"] += $fd->creatures_killed["$creature"] * capturerate }// make capture rate value
 							$fd->creatures_killed["$creature"] = 0; 
 						}
 


### PR DESCRIPTION
zain's idea for if defender has creature capture.

0-Sep 16:38 zain: If CC and BFI = true. Use a stored value of "capture ratio" at line 519. Then use creature.loss += ceil(creature.killed \* capture ratio). End it with creature.killed = 0.
