### PR TITLE
Update battle_calculator.php5

### DIFF
--- a/revolution/battle_calculator.php5
+++ b/revolution/battle_calculator.php5
@@ -86,8 +86,8 @@ class BattleCalculator {
 			// Time to compute Damage
 			$total_attackers->damage = $this->get_damage($total_defenders, $total_attackers);
 			$total_defenders->damage = $this->get_damage($total_attackers, $total_defenders);
-			$total_attackers->captured = $this->get_creature_capture($total_defenders*2.0, $total_attackers);
-			$total_defenders->captured = $this->get_creature_capture($total_attackers, $total_defenders);
+			$total_attackers->captured = $this->get_creature_capture_att($total_defenders, $total_attackers);
+			$total_defenders->captured = $this->get_creature_capture_def($total_attackers, $total_defenders);
 			$total_attackers->structures_captured = $this->get_structure_capture($total_attackers, $total_defenders);
 			$cap_structures = floor (($pd->unassigned + $pd->extractor + $pd->genetic_lab + $pd->powerplant + $pd->factory) * 0.10);
 			if ($total_defenders->damage == 100) {
@@ -515,7 +515,19 @@ class BattleCalculator {
 		return $damage;
 	}
 
-	function get_creature_capture($attack, $defense) {
+	function get_creature_capture_att($attack, $defense) {
+		$capture_ratio = ($attack->int*2)/($defense->dis+1);
+		if ($capture_ratio > 2.0) $damage = 10;
+		else if ($capture_ratio > 1.0) $damage = 5;
+		else if ($capture_ratio > 0.5) $damage = 3;
+		else if ($capture_ratio > 0.1) $damage = 2;
+		else if ($capture_ratio > 0.05) $damage = 1;
+		
+		else $damage = 0;
+		
+		return $damage;
+	}
+	function get_creature_capture_def($attack, $defense) {
 		$capture_ratio = $attack->int/($defense->dis+1);
 		if ($capture_ratio > 2.0) $damage = 10;
 		else if ($capture_ratio > 1.0) $damage = 5;


### PR DESCRIPTION
I changed the code because I still think the *2 is the problem. If it is the problem then the bug will now be fixed, if it is not then nothing will change.

I added two separate get creature capture functions, one for attackers and one for defenders and then I added the *2 directly to the defenders int. I do not think you can multiply a FleetData object by a number.

Further I looked thoroughly through the code and there is no problem on or around line 170, its a bit confusing at first but I am positive everything works fine there. 

And just to reiterate the bug we are trying to correct makes ALL attacking creatures immune to capture whether the attacker has FBI or not. I'm not sure when this bug came around but it may have been before you commented out line 170.
